### PR TITLE
do not double url encode values

### DIFF
--- a/backend/app/services/qualtrics_launcher.rb
+++ b/backend/app/services/qualtrics_launcher.rb
@@ -43,8 +43,7 @@ class QualtricsLauncher
       ['study_id', study_id]
     ].map { |k, v| "#{k}=#{v}" }.join('&')
     hash = md5_hash(raw_query)
-    unecrypted_token = "#{raw_query}&mac=#{hash}"
-    encrypt(unecrypted_token)
+    encrypt("#{raw_query}&mac=#{hash}")
   end
 
   def encrypt(value)

--- a/backend/app/services/qualtrics_launcher.rb
+++ b/backend/app/services/qualtrics_launcher.rb
@@ -30,6 +30,10 @@ class QualtricsLauncher
   attr_reader :user_id
 
   def sso_token
+    # these values will be url encoded along with the md5hash in the url method.
+    # if we encode them here before generating the md5sum,
+    # qualtrics will fail to properly decode them, causing
+    # slashes in the "return_to_url" to be percent escaped.
     raw_query = [
       ['timestamp', Time.now.utc.iso8601],
       ['expiration', 1.hour.from_now.utc.iso8601],

--- a/backend/app/services/qualtrics_launcher.rb
+++ b/backend/app/services/qualtrics_launcher.rb
@@ -30,16 +30,14 @@ class QualtricsLauncher
   attr_reader :user_id
 
   def sso_token
-    raw_query = URI.encode_www_form(
-      [
-        ['timestamp', Time.now.utc.iso8601],
-        ['expiration', 1.hour.from_now.utc.iso8601],
-        ['research_id', ResearchId.for_user_id(user_id).id],
-        ['return_to_url', frontend_returning_url(study_id: study_id)],
-        ['is_testing', !Kinetic.is_production?],
-        ['study_id', study_id]
-      ]
-    )
+    raw_query = [
+      ['timestamp', Time.now.utc.iso8601],
+      ['expiration', 1.hour.from_now.utc.iso8601],
+      ['research_id', ResearchId.for_user_id(user_id).id],
+      ['return_to_url', frontend_returning_url(study_id: study_id)],
+      ['is_testing', !Kinetic.is_production?],
+      ['study_id', study_id]
+    ].map { |k, v| "#{k}=#{v}" }.join('&')
     hash = md5_hash(raw_query)
     unecrypted_token = "#{raw_query}&mac=#{hash}"
     encrypt(unecrypted_token)


### PR DESCRIPTION
The params were being encoded, hash taken, then encoded again

That caused urls to have their `/` characters doubly encoded