### PR TITLE
Add a minimal Doorkeeper config

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -44,6 +44,9 @@ gem 'qualtrics_api',
 
 gem 'will_paginate', '~> 3.1.7'
 
+# API versioning and documentation
+gem 'openstax_api', '9.4.1'
+
 gem 'openstax_swagger',
     github: 'openstax/swagger-rails',
     ref: '1df972b4bae1ea1ae7dd2ecac4804b4bf2642ee9'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -472,6 +472,7 @@ DEPENDENCIES
   listen (~> 3.3)
   lograge
   openstax_accounts (= 9.8.0)
+  openstax_api (= 9.4.1)
   openstax_auth!
   openstax_healthcheck
   openstax_swagger!

--- a/backend/config/initializers/doorkeeper.rb
+++ b/backend/config/initializers/doorkeeper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# a minimal doorkeeper config
+# Even though doorkeeper isn't used, it's pulled in by the account-rails gem
+# and will blow up on production if a config isn't present
+Doorkeeper.configure do
+  orm :active_record
+  api_only
+end


### PR DESCRIPTION
accounts-rails needs it to be present even if it's not used, and then in turn it needs openstax_api 