### PR TITLE
use regex for rack:ors

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -7,6 +7,9 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
+# We allow access from certain localhost domains
+# to allow developers to use test local front-ends without
+# running the server locally
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins 'localhost:4000'

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -18,7 +18,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   end
   allow do
     # allow rex development to load eligibility api
-    origins ['localhost:3000', '*.herokuapp.com']
+    origins ['localhost:3000', /herokuapp.com$/]
     resource '/api/v1/eligibility', {
       headers: :any,
       credentials: true,
@@ -26,7 +26,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     }
   end
   allow do
-    origins ['localhost:4000', '*.openstax.org']
+    origins ['localhost:4000', /openstax.org$/]
     resource '/api/*', {
       headers: :any,
       credentials: true,


### PR DESCRIPTION
The earlier #108 didn't work, and reading https://github.com/cyu/rack-cors carefully there's no mention of using wildcards with strings on origin checks, it suggests regex