### PR TITLE
default abort flag to inverse of consent

### DIFF
--- a/frontend/specs/participant.spec.ts
+++ b/frontend/specs/participant.spec.ts
@@ -94,16 +94,21 @@ test('launching study and aborting it', async ({ page }) => {
     await goToPage({ page, path: `/study/details/${studyId}`, loginAs: 'user' })
     await page.click('testId=launch-study')
 
-    // qualtrics will redirect here once complete
-    await goToPage({ page, path: `/study/land/${studyId}?abort=true`, loginAs: 'user' })
+    await goToPage({ page, path: `/study/land/${studyId}?consent=false`, loginAs: 'user' })
+    await expect(page).not.toMatchText(/marked as complete/)
 
     await page.click('testId=view-studies')
     await expect(page).toHaveSelector(`[data-study-id="${studyId}"][aria-disabled="false"]`)
+
     await page.click(`[data-study-id="${studyId}"]`)
     // should have navigated
     expect(
         await page.evaluate(() => document.location.pathname)
     ).toMatch(RegExp(`/study/details/${studyId}$`))
+
+    // now mark complete with consent granted
+    await goToPage({ page, path: `/study/land/${studyId}?consent=true`, loginAs: 'user' })
+    await expect(page).toMatchText(/marked as complete/)
 
     await rmStudy({ page, studyId })
 })

--- a/frontend/src/screens/study-landing.tsx
+++ b/frontend/src/screens/study-landing.tsx
@@ -23,10 +23,11 @@ const Points:React.FC<{ study: ParticipantStudy }> = ({ study }) => {
 
 const CompletedMessage:React.FC<{
     consented: boolean,
+    aborted: boolean
     study: ParticipantStudy,
     onReturnClick(): void,
 }> = ({
-    consented, study, onReturnClick,
+    consented, aborted, study, onReturnClick,
 }) => (
     <Box justify="center">
         <Box
@@ -46,7 +47,7 @@ const CompletedMessage:React.FC<{
                 <h3>Success!</h3>
                 <h5 css={{ lineHeight: '150%', marginBottom: '3rem' }}>
                     You‘ve completed a Kinetic activity.
-                    This task will be marked as complete on your dashboard.
+                    {!aborted && ' This task will be marked as complete on your dashboard.'}
                 </h5>
                 <Button primary data-test-id="view-studies" onClick={onReturnClick}>Go back to dashboard</Button>
 
@@ -74,8 +75,11 @@ export default function UsersStudies() {
     const api = useStudyApi()
     const history = useHistory()
     const user = useCurrentUser()
-    const abort = useQueryParam('abort') == 'true'
     const noConsent = useQueryParam('consent') == 'false'
+    const abortParam =  useQueryParam('abort')
+    // default abort to whether consent was not granted only if we did not receive an abort param,
+    const abort = abortParam == null ? noConsent : abortParam == 'true'
+
     const md = useQueryParam('md') || {}
     if (!user) {
         return <IncorrectUser />
@@ -116,7 +120,7 @@ export default function UsersStudies() {
     return (
         <div className="container studies mt-8">
             {!study && <LoadingAnimation message="Loading study" />}
-            {study && <CompletedMessage consented={!noConsent} onReturnClick={onNav} study={study} />}
+            {study && <CompletedMessage aborted={abort} consented={!noConsent} onReturnClick={onNav} study={study} />}
         </div>
     )
 


### PR DESCRIPTION
This allows qualtrics study to continue with the behavior of passing consent=false and studies not being marked as completed