### PR TITLE
fix overflowing segment titles on cards

### DIFF
--- a/frontend/src/components/segment-bar.tsx
+++ b/frontend/src/components/segment-bar.tsx
@@ -21,6 +21,10 @@ const segmentStyle: CSSObject = {
     display: 'flex',
     alignItems: 'center',
     flexDirection: 'column',
+    '.title': {
+        marginTop: '5px',
+        lineHeight: '18px',
+    },
     '&:first-of-type': {
         '.title': {
             paddingLeft: segmentTitlePadding,

--- a/frontend/src/screens/learner/card.tsx
+++ b/frontend/src/screens/learner/card.tsx
@@ -98,10 +98,12 @@ const MultiSessionFlag: FC<StudyCardProps> = ({ study }) => {
                 width: 250,
                 backgroundColor: 'white',
                 zIndex: 3,
-                height: 60,
+                height: 80,
                 padding: 20,
+                display: 'flex',
+                flex: 1,
+                overflow: 'hidden',
                 boxShadow: '0px 4px 8px rgb(0 0 0 / 18%)',
-
             }}
         >
             <MultiSessionBar study={study} />

--- a/frontend/src/screens/learner/details.tsx
+++ b/frontend/src/screens/learner/details.tsx
@@ -82,7 +82,7 @@ const MultiSession: FC<StudyDetailsProps> = ({ study }) => {
     if (!study.stages || !studyIsMultipart(study)) return null
 
     return (
-        <Box direction="column" margin={{ bottom: 'xxlarge' }}>
+        <Box direction="column" margin={{ bottom: 'xlarge' }}>
             <Box align='center' gap>
                 <Icon
                     icon="multiStage"


### PR DESCRIPTION
Fixes https://github.com/openstax/research/issues/165

note: we have to be careful when adjusting these styles because the segment bar is used in 3 spots, the top nav for rewards, the details section and the cards.

Before:
<img width="403" alt="image" src="https://user-images.githubusercontent.com/79566/189969872-07d592cd-2cf2-4060-9b3f-c0da07832654.png">


after:
<img width="401" alt="image" src="https://user-images.githubusercontent.com/79566/189969768-125a6fa6-9031-4454-9b3a-4489399903e0.png">
