### PR TITLE
construct "personality" icon using '#' char overlay

### DIFF
--- a/frontend/src/components/packaged-icons.ts
+++ b/frontend/src/components/packaged-icons.ts
@@ -16,6 +16,7 @@ import warning from '@iconify-icons/bi/exclamation-triangle-fill'
 import rolodex from '@iconify-icons/bi/person-rolodex'
 import list from '@iconify-icons/bi/list'
 import multiStage from '@iconify-icons/bi/stack'
+import chatLeft from '@iconify-icons/bi/chat-left-fill'
 
 export const ICONS = {
     x,
@@ -36,4 +37,5 @@ export const ICONS = {
     list,
     right,
     multiStage,
+    chatLeft,
 }

--- a/frontend/src/screens/learner/details.tsx
+++ b/frontend/src/screens/learner/details.tsx
@@ -111,6 +111,7 @@ const Researcher: React.FC<{ researcher?: PublicResearcher }> = ({ researcher })
     )
 }
 
+
 export const StudyDetails: React.FC<{ studies: ParticipantStudy[] }> = ({ studies }) => {
     const { studyId: sid } = useParams<{ studyId: string }>()
     const nav = useNavigate()
@@ -128,7 +129,19 @@ export const StudyDetails: React.FC<{ studies: ParticipantStudy[] }> = ({ studie
             <Box direction="column" flex>
                 <div css={{ overflowY: 'auto', flex: 1 }}>
                     <h3>{study.title}</h3>
-                    {tag && <Box gap align="center" margin={{ vertical: 'large' }}><Icon icon="feedback" color={colors.purple} />{tag}</Box>}
+                    {tag && <Box gap align="center" margin={{ vertical: 'large' }}>
+                        <div css={{ position: 'relative' }}>
+                            <Icon icon="chatLeft" color={colors.purple} />
+                            <span css={{
+                                position: 'absolute',
+                                left: 6,
+                                top: 6,
+                                color: 'white',
+                                fontSize: 7,
+                            }}>#</span>
+                        </div>
+                        {tag}</Box>
+                    }
                     <Box gap align="center" margin={{ bottom: 'large' }}>
                         <Icon icon="clock" color={colors.purple} />
                         <div>{study.durationMinutes} min</div>


### PR DESCRIPTION
This is how the figma did it, which meant there wasn't an straight SVG to download.  this seems to work well though

fixes https://github.com/openstax/research/issues/205

<img width="207" alt="image" src="https://user-images.githubusercontent.com/79566/193836278-78b192bf-f8a2-4976-ad6d-22cc13a8356c.png">
