### PR TITLE
fix rewards bar overflow on mobile

### DIFF
--- a/frontend/src/components/rewards-progress-bar.tsx
+++ b/frontend/src/components/rewards-progress-bar.tsx
@@ -162,6 +162,8 @@ const SegmentInfo: React.FC<{ schedule: RewardsSegment[] }> = ({ schedule }) => 
     )
 }
 
+const FINAL_STEP_WIDTH = 50
+
 export const RewardsProgressBar: React.FC<RewardsProgressBarProps> = ({ studies }) => {
     const {
         schedule,
@@ -182,7 +184,7 @@ export const RewardsProgressBar: React.FC<RewardsProgressBarProps> = ({ studies 
 
                 <Box align="start" padding={{ top: 'large' }} gap css={{
                     height: 60,
-                    paddingRight: '20px',
+                    paddingRight: FINAL_STEP_WIDTH,
                 }}>
                     <Box direction='column' margin={{ top: '-10px' }}>
                         <b>{pointsEarned} / {totalPoints} pts</b>
@@ -192,7 +194,7 @@ export const RewardsProgressBar: React.FC<RewardsProgressBarProps> = ({ studies 
                         {schedule.map((segment) => (
                             <Segment
                                 key={segment.index}
-                                margin={segment.isFinal ? { top: -10, left: 50 } : {}}
+                                margin={segment.isFinal ? { top: -10, left: FINAL_STEP_WIDTH } : {}}
                                 percentage={(segment.points / totalPoints) * 100
                                 }
                             >


### PR DESCRIPTION

<img width="846" alt="image" src="https://user-images.githubusercontent.com/79566/194613900-aca3c0cc-0918-490c-95dd-dcd5a4145762.png">


resolves overflow in https://github.com/openstax/research/issues/202