### PR TITLE
Cleanup theme colors and organize naming per specs

### DIFF
--- a/frontend/src/components/footer.tsx
+++ b/frontend/src/components/footer.tsx
@@ -67,7 +67,7 @@ const Funders = () => {
 
 export const MobileFooter: React.FC<{ className?: string, includeFunders?: boolean }> = () => {
     return (
-        <div css={{ backgroundColor: colors.darkBlue, color: 'white', a: { color: 'white' } }}>
+        <div css={{ backgroundColor: colors.blue, color: 'white', a: { color: 'white' } }}>
             <div className='container-lg'>
                 <Row className="py-1">
                     <Row className="py-1">
@@ -108,7 +108,7 @@ export const MobileFooter: React.FC<{ className?: string, includeFunders?: boole
 
 export const DesktopFooter: React.FC<{ className?: string, includeFunders?: boolean }> = () => {
     return (
-        <div css={{ backgroundColor: colors.darkBlue, color: 'white', a: { color: 'white' } }}>
+        <div css={{ backgroundColor: colors.blue, color: 'white', a: { color: 'white' } }}>
             <div className='container-lg'>
                 <Row css={{ padding: '20px 0' }}>
                     <Col auto direction="column">

--- a/frontend/src/components/ox-colored-stripe.tsx
+++ b/frontend/src/components/ox-colored-stripe.tsx
@@ -1,14 +1,27 @@
-import { React } from '../common'
+import { Box, React } from '../common'
 import { colors } from '../theme'
 
 export const OXColoredStripe = () => (
-    <div
-        className="ox-colored-stripe"
-        css={{ height: '10px', display: 'flex' }}
-    >
-        <div css={{ flex: 1,  backgroundColor: colors.orange  }} />
-        <div css={{ flex: 1,  backgroundColor: colors.darkBlue  }} />
-        <div css={{ flex: 1,  backgroundColor: colors.red  }} />
-        <div css={{ flex: 1,  backgroundColor: colors.teal  }} />
-    </div>
+    <Box height="10" className="ox-colored-stripe">
+        <span css={{
+            backgroundColor: colors.orange,
+            flex: 3.5,
+        }}></span>
+        <span css={{
+            backgroundColor: colors.primaryBlue,
+            flex: 1.5,
+        }}></span>
+        <span css={{
+            backgroundColor: colors.red,
+            flex: 1,
+        }}></span>
+        <span css={{
+            backgroundColor: colors.yellow,
+            flex: 2.5,
+        }}></span>
+        <span css={{
+            backgroundColor: colors.teal,
+            flex: 1.5,
+        }}></span>
+    </Box>
 )

--- a/frontend/src/components/styled-buttons.tsx
+++ b/frontend/src/components/styled-buttons.tsx
@@ -12,11 +12,11 @@ interface LinkButtonProps extends ButtonProps {
 
 export const StyledLinkButton = styled(Button)<ButtonProps>({
     svg: {
-        color: colors.linkButtonIcon,
+        color: colors.lightGray,
     },
     '&:hover': {
         svg: {
-            color: colors.linkButtonIconHover,
+            color: colors.blue,
         },
     },
 })

--- a/frontend/src/screens/learner/card.tsx
+++ b/frontend/src/screens/learner/card.tsx
@@ -53,7 +53,7 @@ const Researchers: React.FC<StudyCardProps> = ({ study }) => {
     if (!names.length) return null
 
     return (
-        <span css={{ color: colors.blackText }}>{toSentence(names)}</span>
+        <span>{toSentence(names)}</span>
     )
 }
 
@@ -63,7 +63,7 @@ const Feedback: React.FC<StudyCardProps> = ({ study }) => {
     return (
         <Box align='center' gap>
             <Icon height={15} icon="feedback" color={colors.purple} />
-            <span css={{ color: colors.darkText }}>Feedback Available</span>
+            <span>Feedback Available</span>
         </Box>
     )
 }
@@ -80,7 +80,7 @@ const MultiSession: React.FC<StudyCardProps> = ({ study }) => {
                 tooltipProps={{ displayType: 'tooltip' }}
                 tooltip="This study has multiple sessions. The other sessions will be released once available."
             />
-            <span css={{ color: colors.darkText }}>Multi-Session</span>
+            <span>Multi-Session</span>
         </Box>
     )
 }
@@ -93,7 +93,6 @@ const CompleteFlag: React.FC<StudyCardProps> = ({ study }) => {
             align="center"
             padding="default"
             css={{
-                color: colors.blackText,
                 backgroundColor: colors.green,
                 position: 'absolute',
                 borderBottomLeftRadius: 20,
@@ -114,7 +113,6 @@ const MultiSessionFlag: FC<StudyCardProps> = ({ study }) => {
     return (
         <div
             css={{
-                color: colors.blackText,
                 position: 'absolute',
                 borderBottomLeftRadius: 20,
                 borderTopLeftRadius: 20,

--- a/frontend/src/screens/learner/details.tsx
+++ b/frontend/src/screens/learner/details.tsx
@@ -21,7 +21,7 @@ const Part: FCWC<{ title: string, icon: IconKey }> = ({
         <Box direction="column" margin={{ bottom: 'large' }}>
             <Box align='center' gap margin={{ vertical: 'default' }}>
                 <Icon icon={icon} color={colors.purple} />
-                <span css={{ color: colors.darkText }}>{title}</span>
+                <span>{title}</span>
             </Box>
             <div css={{ marginBottom: '0.5rem', color: colors.grayText }}>{children}</div>
         </Box>
@@ -86,7 +86,7 @@ const MultiSession: FC<StudyDetailsProps> = ({ study }) => {
                     icon="multiStage"
                     color={colors.purple}
                 />
-                <span css={{ color: colors.darkText }}>Multi-Session</span>
+                <span>Multi-Session</span>
             </Box>
             <Box margin={{ vertical: 'large' }}>
                 <MultiSessionBar study={study} />

--- a/frontend/src/styles/bootstrap.scss
+++ b/frontend/src/styles/bootstrap.scss
@@ -8,6 +8,22 @@ $h3-font-size: $font-size-base * 1.5 !default;
 $h4-font-size: $font-size-base * 1.25 !default;
 $h5-font-size: $font-size-base * 1.125 !default;
 $h6-font-size: $font-size-base !default;
+$small-font-size: $font-size-base * .875 !default;
+$x-small-font-size: $font-size-base * .75 !default;
+$xx-small-font-size: $font-size-base * .6875 !default;
+$body-color: #424242;
+
+.small {
+    font-size: $small-font-size;
+}
+
+.x-small {
+    font-size: $x-small-font-size;
+}
+
+.xx-small {
+    font-size: $xx-small-font-size;
+}
 
 $font-sizes: (
     1: $h1-font-size,
@@ -17,18 +33,6 @@ $font-sizes: (
     5: $h5-font-size,
     6: $h6-font-size
 );
-
-.small {
-    font-size: $font-size-base * .875;
-}
-
-.x-small {
-    font-size: $font-size-base * .75;
-}
-
-.xx-small {
-    font-size: $font-size-base * .6875;
-}
 
 $spacer: 1rem;
 $spacers: ();

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,10 +1,12 @@
 
 export const colors = {
     pageBackground: '#f7f8fa',
-    orange: '#f47641',
-    darkBlue: '#151B2C',
+    orange: '#f47541',
+    blue: '#151B2C',
+    primaryBlue: '#002469',
     red: '#ca2026',
-    teal: '#0dc0de',
+    yellow: '#F4D019',
+    teal: '#0DC0DC',
     darkTeal: '#039AC4',
     purple: '#6922EA',
     gray: '#E8E8E8',
@@ -13,12 +15,8 @@ export const colors = {
     darkGray: '#989898',
     text: '#212529',
     grayText: '#848484',
-    darkText: '#151B2C',
-    blackText: '#424242',
     input: { border: '#ced4da' },
     line: '#cfcfcf',
-    linkButtonIcon: '#DBDBDB',
-    linkButtonIconHover: '#151B2C',
     white: '#ffffff',
 }
 


### PR DESCRIPTION
Viki updated some [specs around color](https://docs.google.com/document/d/1Rw5y4xlylS2wcu0qUljJHV1RMXulUxYYGUNJyt94iLY/edit#heading=h.d9qgt6saek69)

Default text on the site is updated and made a lot of inline `css` redundant