### PR TITLE
set a min-height for modal content

### DIFF
--- a/frontend/src/screens/studies/modal.tsx
+++ b/frontend/src/screens/studies/modal.tsx
@@ -58,7 +58,7 @@ export const StudyModal:React.FC<StudyModalProps> = ({ onHide, study }) => {
             title={title}
             data-is-study-preview-modal={isPreview}
         >
-            <Modal.Body css={{ padding: 0 }}>
+            <Modal.Body css={{ padding: 0, minHeight: 'calc(100vh - 130px)' }}>
                 {isNil(studyUrl) && <LoadingAnimation />}
                 <Iframe url={studyUrl} onClose={onHide} />
             </Modal.Body>


### PR DESCRIPTION
Something seems to have changed and qualtrics content inside the iframe no longer has a height attached to it, causing the iframe to no longer expand

