### PR TITLE
turn off ip spoofing checks

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -21,6 +21,10 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
+  # disable ip spoofing safeguard
+  # cloudfront will occasionally send a mismatched ip and trigger it
+  config.action_dispatch.ip_spoofing_check = false
+
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = true # ENV['RAILS_SERVE_STATIC_FILES'].present?


### PR DESCRIPTION
It seems like occasionally cloudfront will set the HTTP_X_FORWARDED_FOR to multiple IPs and trigger that check to fail.  symptoms are a ActionDispatch::RemoteIp::IpSpoofAttackError being raised resulting in a 500 error