### PR TITLE
Reorganized the quick link section and the search container

### DIFF
--- a/frontend/src/screens/learner.tsx
+++ b/frontend/src/screens/learner.tsx
@@ -193,6 +193,74 @@ const StudyDuration: FC<{duration: Set<Number>, setDuration: Function, durationT
         </Flex>
     )
 }
+
+const QuickLinks: FC<{filteredStudies: ParticipantStudy[]}> = ({ filteredStudies }) => {
+
+    const [learningPaths, studiesByLearningPath, completedStudiesByLearningPath] = useMemo(() => {
+        return [
+            orderBy(
+                (uniqBy(filteredStudies.map(fs => fs.learningPath), (lp) => lp?.label)),
+                ['completed', 'order'],
+                ['asc', 'asc']
+            ),
+            groupBy(filteredStudies, (study) => {
+                return study.learningPath?.label
+            }),
+            groupBy(filter(filteredStudies, (study) => study.completedAt != null), (study) => {
+                return study.learningPath?.label
+            }),
+        ]
+    }, [filteredStudies])
+
+    const isMobile = useIsMobileDevice()
+
+    const scrollToLearningPath = (learningPath: string) => {
+        document.getElementById(learningPath)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+
+    const [hoveredLearningPath, setHoveredLearningPath] = useState<string | null>(null)
+
+    const handleMouseEnter = (learningPath: string) => {
+        setHoveredLearningPath(learningPath)
+    }
+
+    const handleMouseLeave = () => {
+        setHoveredLearningPath(null)
+    }
+
+    return (
+        <Stack 
+            w='25%' 
+            p='1rem 1.5rem 1.5rem 2.5rem'
+            justify='flex-start'
+            gap='lg'
+            display={ isMobile? 'none' : 'flex' }
+        >
+            {learningPaths.map(learningPath => {
+                if (!learningPath) return null
+                return (
+                    <Group 
+                        key={learningPath.label}
+                        style={{ cursor: 'pointer' }}
+                        c={ hoveredLearningPath === learningPath.label ? colors.blue : colors.gray70 }
+                        onClick={() => scrollToLearningPath(learningPath.label)}
+                        onMouseEnter={() => handleMouseEnter(learningPath.label)}
+                        onMouseLeave={handleMouseLeave}
+                        justify='space-between'
+                    >
+                        <Text>{learningPath.label}</Text>
+                        <Text>
+                            {completedStudiesByLearningPath[learningPath.label]? completedStudiesByLearningPath[learningPath.label].length : 0}
+                        /
+                            {studiesByLearningPath[learningPath.label].length}
+                        </Text>
+                    </Group>
+                )
+            })}
+        </Stack>
+    )
+}
+
 export const StudiesContainer = () => {
     const { search, setSearch, duration, setDuration, filteredStudies } = useSearchStudies()
 
@@ -200,18 +268,23 @@ export const StudiesContainer = () => {
         <Container pt='1.5rem' bg={colors.ash}>
             <Stack gap='lg'>
                 <StudiesTitle search={search} filteredStudies={filteredStudies} />
-                <Group justify='space-between' wrap='wrap' >
-                    <Flex justify='center' align='center' gap='md'>
-                        <StudyDuration duration={duration} durationText={5} setDuration={setDuration}></StudyDuration>
-                        <StudyDuration duration={duration} durationText={15} setDuration={setDuration}></StudyDuration>
-                        <StudyDuration duration={duration} durationText={25} setDuration={setDuration}></StudyDuration>
-                    </Flex>
-                    <SearchBar search={search} setSearch={setSearch} />
-                </Group>
+                <Flex gap='xl'>
+                    <QuickLinks filteredStudies={filteredStudies} />
+                    <Stack w='75%' pl='1rem'>
+                        <Group justify='space-between' wrap='wrap' pt='.5rem' pb='1.5rem'>
+                            <Flex justify='center' align='center' gap='md'>
+                                <StudyDuration duration={duration} durationText={5} setDuration={setDuration}></StudyDuration>
+                                <StudyDuration duration={duration} durationText={15} setDuration={setDuration}></StudyDuration>
+                                <StudyDuration duration={duration} durationText={25} setDuration={setDuration}></StudyDuration>
+                            </Flex>
+                            <SearchBar search={search} setSearch={setSearch} />
+                        </Group>
 
-                <SearchResults search={search} filteredStudies={filteredStudies} />
+                        <SearchResults search={search} filteredStudies={filteredStudies} />
 
-                <StudiesByLearningPath filteredStudies={filteredStudies} />
+                        <StudiesByLearningPath filteredStudies={filteredStudies} />  
+                    </Stack> 
+                </Flex>
             </Stack>
         </Container>
     )
@@ -304,7 +377,7 @@ export const DesktopStudyCards: FC<{studies: ParticipantStudy[]}> = ({ studies }
 }
 
 export const StudiesByLearningPath: FC<{filteredStudies: ParticipantStudy[]}> = ({ filteredStudies }) => {
-    const [learningPaths, studiesByLearningPath, completedStudiesByLearningPath] = useMemo(() => {
+    const [learningPaths, studiesByLearningPath] = useMemo(() => {
         return [
             orderBy(
                 (uniqBy(filteredStudies.map(fs => fs.learningPath), (lp) => lp?.label)),
@@ -314,88 +387,39 @@ export const StudiesByLearningPath: FC<{filteredStudies: ParticipantStudy[]}> = 
             groupBy(filteredStudies, (study) => {
                 return study.learningPath?.label
             }),
-            groupBy(filter(filteredStudies, (study) => study.completedAt != null), (study) => {
-                return study.learningPath?.label
-            }),
         ]
     }, [filteredStudies])
 
     const isMobile = useIsMobileDevice()
 
-    const scrollToLearningPath = (learningPath: string) => {
-        document.getElementById(learningPath)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-    }
-
-    const [hoveredLearningPath, setHoveredLearningPath] = useState<string | null>(null)
-
-    const handleMouseEnter = (learningPath: string) => {
-        setHoveredLearningPath(learningPath)
-    }
-
-    const handleMouseLeave = () => {
-        setHoveredLearningPath(null)
-    }
-
     return (
-        <Flex direction='row' gap='xl'>
-            <Flex 
-                w='25%' 
-                p='1rem 1.5rem 1.5rem 2.5rem'
-                justify-content='center'
-                direction='column'
-                display={ isMobile? 'none' : 'flex' }
-            >
-                {learningPaths.map(learningPath => {
-                    if (!learningPath) return null
-                    return (
-                        <Flex 
-                            key={learningPath.label}
-                            style={{ cursor: 'pointer' }}
-                            c={ hoveredLearningPath === learningPath.label ? colors.blue : colors.gray70 }
-                            onClick={() => scrollToLearningPath(learningPath.label)}
-                            onMouseEnter={() => handleMouseEnter(learningPath.label)}
-                            onMouseLeave={handleMouseLeave}
-                            justify='space-between'
-                            mb='1rem'
-                        >
-                            <Text>{learningPath.label}</Text>
-                            <Text>
-                                {completedStudiesByLearningPath[learningPath.label]? completedStudiesByLearningPath[learningPath.label].length : 0}
-                                /
-                                {studiesByLearningPath[learningPath.label].length}
-                            </Text>
-                        </Flex>
-                    )
-                })}
-            </Flex>
-            <Stack w='75%'  gap='lg' data-testid='studies-listing' c={colors.text}>
-                {learningPaths.map(learningPath => {
-                    if (!learningPath) return null
-                    const studies = sortBy(studiesByLearningPath[learningPath.label], (study) => !!study.completedAt)
-                    return (
-                        <Stack 
-                            w='100%'
-                            key={learningPath.label}
-                            id={learningPath.label}
-                        >
-                            <Group gap='sm'>
-                                <Title order={3} c={colors.gray90}>
-                                    {learningPath.label}
-                                </Title>
-                                <Text span>|</Text>
-                                <Title order={3} fw='300'>
-                                    {learningPath.description}
-                                </Title>
-                            </Group>
-                            {isMobile ?
-                                <MobileStudyCards studies={studies} /> :
-                                <DesktopStudyCards studies={studies} />
-                            }
-                        </Stack>
-                    )
-                })}
-            </Stack>
-        </Flex>
+        <Stack gap='lg' data-testid='studies-listing' c={colors.text}>
+            {learningPaths.map(learningPath => {
+                if (!learningPath) return null
+                const studies = sortBy(studiesByLearningPath[learningPath.label], (study) => !!study.completedAt)
+                return (
+                    <Stack 
+                        w='100%'
+                        key={learningPath.label}
+                        id={learningPath.label}
+                    >
+                        <Group gap='sm'>
+                            <Title order={3} c={colors.gray90}>
+                                {learningPath.label}
+                            </Title>
+                            <Text span>|</Text>
+                            <Title order={3} fw='300'>
+                                {learningPath.description}
+                            </Title>
+                        </Group>
+                        {isMobile ?
+                            <MobileStudyCards studies={studies} /> :
+                            <DesktopStudyCards studies={studies} />
+                        }
+                    </Stack>
+                )
+            })}
+        </Stack>
     )
 }
 


### PR DESCRIPTION
The search container along with duration filters is now reorganised and is beside the quick links section, as per the design [spec](https://www.figma.com/design/MVxS1h1qovYyDqbWf3DTyF/Version-3.0-Apr24?node-id=1706-1546&m=dev)