### PR TITLE
Fixed the obf email issue

### DIFF
--- a/backend/app/services/open_badge_api.rb
+++ b/backend/app/services/open_badge_api.rb
@@ -49,8 +49,10 @@ class OpenBadgeApi
   # Can also use this format:
   # "Firstname Lastname <email@example.com>"
   def issue_badge(badge_id, emails)
-    HTTPX.accept('application/json')
-      .post("https://openbadgefactory.com/v1/badge/#{@client_id}/#{badge_id}", form: {
+    HTTPX.plugin(:auth)
+      .with(headers: { 'content-type' => 'application/json' })
+      .authorization("Bearer #{token}")
+      .post("https://openbadgefactory.com/v1/badge/#{@client_id}/#{badge_id}", json: {
               recipient: emails
             })
   end

--- a/backend/app/services/user_info.rb
+++ b/backend/app/services/user_info.rb
@@ -83,6 +83,7 @@ class UserInfo
               full_name: u[:name],
               first_name: u[:first_name],
               last_name: u[:last_name],
+              'email_address' => "#{u[:first_name]}-#{u[:last_name]}@test.openstax.org",
               contact_infos: [{
                 type: 'EmailAddress', value: "#{u[:first_name]}-#{u[:last_name]}@test.openstax.org"
               }]


### PR DESCRIPTION
Added the authorization token to the http request and changed it from form to json as per the API documentation. @chrisbendel you were right, the email_address is handled differently in production and development. I have also modified the development userInfo object to match the production one