### PR TITLE
Improving application performance

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -65,6 +65,8 @@ gem 'sssecrets' # for generating api keys
 
 gem 'image_processing'
 
+gem 'rufus-scheduler'
+
 group :test do
   # Any test specific gems
 end

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -174,6 +174,8 @@ GEM
     equalizer (0.0.11)
     erubi (1.12.0)
     erubis (2.7.0)
+    et-orbi (1.2.11)
+      tzinfo
     exception_notification (4.5.0)
       actionmailer (>= 5.2, < 8)
       activesupport (>= 5.2, < 8)
@@ -213,6 +215,9 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     ffi (1.16.3)
+    fugit (1.11.1)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -383,6 +388,7 @@ GEM
     public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.7.3)
     rack (3.0.9.1)
     rack-cors (2.0.2)
@@ -512,6 +518,8 @@ GEM
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (3.0.0.alpha)
+    rufus-scheduler (3.9.2)
+      fugit (~> 1.1, >= 1.11.1)
     sentry-rails (5.17.1)
       railties (>= 5.0)
       sentry-ruby (~> 5.17.1)
@@ -608,6 +616,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   rubyzip (= 3.0.0.alpha)
+  rufus-scheduler
   sentry-rails
   sentry-ruby
   solargraph

--- a/backend/app/services/open_badge_api.rb
+++ b/backend/app/services/open_badge_api.rb
@@ -23,6 +23,16 @@ class OpenBadgeApi
     end
   end
 
+  def fetch_badges
+    response = HTTPX.plugin(:auth)
+                 .with(headers: { 'content-type' => 'application/json' })
+                 .authorization("Bearer #{token}")
+                 .get("https://openbadgefactory.com/v1/badge/#{@client_id}")
+
+    json_objects = response.body.to_s.split("\n").map(&:strip).reject(&:empty?)
+    json_objects.map { |json_str| JSON.parse(json_str) }
+  end
+
   def badge_info(badge_id)
     return if badge_id.blank?
 

--- a/backend/config/initializers/schedule.rb
+++ b/backend/config/initializers/schedule.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rufus-scheduler'
+scheduler = Rufus::Scheduler.new
+
+def populate_badges
+  puts 'Starting the badge schedule'
+  badges = OpenBadgeApi.instance.fetch_badges
+  badge_ids = badges.map { |badge| badge['id'] }
+  badge_ids.each do |id|
+    OpenBadgeApi.instance.badge_info(id)
+  end
+  puts 'Fetched badges for the day'
+end
+
+# Run the job immediately
+scheduler.in '30s' do
+  populate_badges
+end
+
+# Then schedule it to run every 24 hours
+scheduler.every '24h' do
+  populate_badges
+end


### PR DESCRIPTION
- This PR sets up a cron job, to fetch the badges every 24h. The task is also run immediately after the application starts up.
- Utilized rufus-scheduler to setup the cron job.
- The badge ids are fetched first, followed by badge info.