### PR TITLE
Added user notifications

### DIFF
--- a/backend/app/controllers/api/v1/participant/studies_controller.rb
+++ b/backend/app/controllers/api/v1/participant/studies_controller.rb
@@ -5,6 +5,9 @@ class Api::V1::Participant::StudiesController < Api::V1::BaseController
   before_action :set_study, only: [:launch, :land, :stats]
 
   def index
+    current_user_preference = UserPreferences.find_or_initialize_by(user_id: current_user.id)
+    current_user_preference.update!(last_visited_at: Time.current, nurturing_email_sent: false)
+    
     studies = participant_studies
 
     response_binding = Api::V1::Bindings::ParticipantStudies.new(

--- a/backend/app/controllers/api/v1/researcher/studies_controller.rb
+++ b/backend/app/controllers/api/v1/researcher/studies_controller.rb
@@ -69,6 +69,23 @@ class Api::V1::Researcher::StudiesController < Api::V1::Researcher::BaseControll
 
     @study.update_status!(params[:status_action], params[:stage_index])
 
+    if params[:status_action] == 'launch'
+      user_uuids = UserPreferences.where(study_available_email: true).pluck(:user_id)
+      user_uuids.each do |uuid|
+        user_info = UserInfo.for_uuid(uuid)
+
+        recipient = Struct.new(:email_address, :full_name).new(
+          user_info['email_address'],
+          user_info[:full_name]
+        )
+
+        UserMailer
+          .with(user: recipient, study: @study)
+          .new_studies
+          .deliver_now
+      end
+    end
+
     render json: Api::V1::Bindings::Study.create_from_model(@study), status: :ok
   end
 

--- a/backend/app/mailers/user_mailer.rb
+++ b/backend/app/mailers/user_mailer.rb
@@ -42,6 +42,19 @@ class UserMailer < ApplicationMailer
     end
   end
 
+  def nurturing_email
+    mail(
+      to: params[:user].email_address,
+      subject: 'We miss you. Exciting Study Paths Await You!',
+      template: 'nurturing email'
+    ) { |format| format.text { render plain: '' } }.tap do |message|
+      message.mailgun_variables = {
+        'first_name' => params[:user].first_name,
+        'studyPathTitle' => params[:initiated_learning_path] ? params[:initiated_learning_path].label : params[:not_initiated_learning_path].label,
+      }
+    end
+  end
+
   def upcoming_prize_cycle_deadline
     mail(
       to: params[:user].email_address,
@@ -63,8 +76,20 @@ class UserMailer < ApplicationMailer
     ) { |format| format.text { render plain: '' } }.tap do |message|
       message.mailgun_variables = {
         'full_name' => params[:user].full_name,
-        'study_one_title' => params[:studies].first.title_for_participants,
-        'study_two_title' => params[:studies].last.title_for_participants
+        'newStudyTitle' => params[:study].title_for_participants
+      }
+    end
+  end
+
+  def new_learning_path
+    mail(
+      to: params[:user].email_address,
+      subject: 'A new study path awaits you!',
+      template: 'new_study_path'
+    ) { |format| format.text { render plain: '' } }.tap do |message|
+      message.mailgun_variables = {
+        'first_name' => params[:user].first_name,
+        'new_studyPathTitle' => params[:learning_path].title
       }
     end
   end

--- a/backend/app/models/launched_study.rb
+++ b/backend/app/models/launched_study.rb
@@ -30,6 +30,19 @@ class LaunchedStudy < ApplicationRecord
     update!(completed_at: Time.now)
     completed = LaunchedStudy.where(study_id:).complete.count
     Study.update(study_id, completed_count: completed)
+  
+    total_completed_for_user = LaunchedStudy.where(user_id:).count
+
+    user_info = UserInfo.for_uuid(user_id)
+  
+    recipient = Struct.new(:email_address, :full_name).new(
+      user_info['email_address'],
+      user_info[:full_name]
+    )
+
+    if total_completed_for_user == 1
+      UserMailer.with(user: recipient).welcome.deliver_now
+    end
   end
 
   def aborted!

--- a/backend/config/initializers/schedule.rb
+++ b/backend/config/initializers/schedule.rb
@@ -13,6 +13,79 @@ def populate_badges
   puts 'Fetched badges for the day'
 end
 
+def get_initiated_learning_path(user_id)
+  initiated_learning_paths = LearningPath
+                                 .joins(studies: :launched_studies)
+                                 .where(studies: { is_hidden: false })
+                                 .where(studies: { id: LaunchedStudy.where(user_id: user_id).pluck(:study_id) })
+                                 .group('learning_paths.id')
+                                 .having('COUNT(studies.id) > COUNT(launched_studies.completed_at)')
+  if initiated_learning_paths.any?
+    return initiated_learning_paths.first, true
+  else
+    initiated_learning_path_ids = LaunchedStudy
+                                    .where(user_id: user_id)
+                                    .joins(:study)
+                                    .pluck('studies.learning_path_id')
+
+    selected_learning_path = LearningPath
+                                .where.not(id: initiated_learning_path_ids)
+                                .order('RANDOM()')
+                                .limit(1)
+                                .first
+    return selected_learning_path, false
+  end
+end
+
+def get_inactive_users
+  user_ids = LaunchedStudy
+  .where.not(completed_at: nil) # Only completed studies
+  .where('completed_at >= ?', 60.days.ago) # Within the last 60 days
+  .group(:user_id) # Group by user
+  .having('COUNT(user_id) = 1') # Ensure it's their first study
+  .pluck(:user_id)
+
+  inactive_user_ids = UserPreferences
+           .where(user_id: user_ids)
+           .where('last_visited_at <= ?', 30.days.ago) # Inactive for 30+ days
+           .where(nurturing_email_sent: false) # Haven't received email
+           .pluck(:user_id)
+  
+  inactive_user_ids
+end
+
+def send_notification_to_inactive_users
+
+  inactive_user_ids = get_inactive_users
+  
+  inactive_user_ids.each do |user_id|
+
+    selected_learning_path, is_initiated = get_initiated_learning_path(user_id)
+
+    if !selected_learning_path
+      return
+    end
+
+    user_info = UserInfo.for_uuid(user_id)
+    recipient = Struct.new(:email_address, :first_name).new(
+        user_info['email_address'],
+        user_info[:first_name]
+      )
+
+    UserMailer
+      .with(
+        user: recipient,
+        initiated_learning_path: is_initiated ? selected_learning_path : nil,
+        not_initiated_learning_path: !is_initiated ? selected_learning_path : nil
+      )
+      .nurturing_email
+      .deliver_now
+
+    preference = UserPreferences.find_by(user_id: user_id)
+    preference.update!(nurturing_email_sent: true)
+  end
+end
+
 # Run the job immediately
 scheduler.in '30s' do
   populate_badges
@@ -21,4 +94,5 @@ end
 # Then schedule it to run every 24 hours
 scheduler.every '24h' do
   populate_badges
+  send_notification_to_inactive_users
 end

--- a/backend/db/migrate/20250108005613_add_last_visit_to_user_preferences.rb
+++ b/backend/db/migrate/20250108005613_add_last_visit_to_user_preferences.rb
@@ -1,0 +1,5 @@
+class AddLastVisitToUserPreferences < ActiveRecord::Migration[7.1]
+  def change
+    add_column :user_preferences, :last_visited_at, :datetime, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+  end
+end

--- a/backend/db/migrate/20250108011015_add_nurturing_email_sent_to_user_preferences.rb
+++ b/backend/db/migrate/20250108011015_add_nurturing_email_sent_to_user_preferences.rb
@@ -1,0 +1,5 @@
+class AddNurturingEmailSentToUserPreferences < ActiveRecord::Migration[7.1]
+  def change
+    add_column :user_preferences, :nurturing_email_sent, :boolean, default: false, null: false
+  end
+end


### PR DESCRIPTION
- Send a welcome mail to users when they finish their first study
- Send an email to users when a new study becomes available
- Send an email to users when a new learning path becomes available
- Send an email to inactive users, (when they are inactive for more than 60 days and an email hasn't been sent already)