### PR TITLE
Support a range of months in the activity report

### DIFF
--- a/backend/app/services/learner_activity_report.rb
+++ b/backend/app/services/learner_activity_report.rb
@@ -3,9 +3,28 @@
 require 'csv'
 
 class LearnerActivityReport
+  DEFAULT_MONTHS_AGO = 1
+
   def initialize(months_ago:)
     @months_ago = months_ago
     @user_uuids = []
+  end
+
+  MONTHS_AGO_FORMAT = /\A\s*(\d+)\s*(?:-\s*(\d+)\s*)?\z/
+
+  # Accepts either a single bound ("72" => everything since 72 months ago) or a
+  # range ("12-24" => the window between 12 and 24 months ago).  Range bounds may
+  # be given in either order.  Reporting over a bounded window keeps the account
+  # lookup small enough for Accounts to accept the request.
+  def month_bounds
+    raw = @months_ago.to_s
+    return [DEFAULT_MONTHS_AGO, nil] if raw.strip.empty?
+
+    match = MONTHS_AGO_FORMAT.match(raw)
+    raise ArgumentError, "expected a month or a range of months, got: #{@months_ago.inspect}" unless match
+
+    newest, oldest = match.captures.compact.map(&:to_i)
+    oldest ? [[newest, oldest].min, [newest, oldest].max] : [newest, nil]
   end
 
   def as_csv_string
@@ -36,8 +55,10 @@ class LearnerActivityReport
     ]
   end
 
+  # A participant appears once per launched stage, so plucking without de-duping
+  # sends the same uuid to Accounts many times over and can overflow the request.
   def get_users(launches)
-    @user_uuids = launches.clone.pluck('user_id')
+    @user_uuids = launches.clone.distinct.pluck('launched_stages.user_id')
     UserInfo.for_uuids(@user_uuids)
   end
 
@@ -95,10 +116,19 @@ class LearnerActivityReport
     end
   end
 
+  def launches
+    newest, oldest = month_bounds
+
+    scope = LaunchedStage
+              .joins(stage: :study)
+              .where('first_launched_at >= ?', (oldest || newest).months.ago)
+
+    scope = scope.where('first_launched_at < ?', newest.months.ago) if oldest
+    scope
+  end
+
   def generate_report(csv)
-    launches = LaunchedStage
-                 .joins(stage: :study)
-                 .where('first_launched_at >= ?', (@months_ago || 1).to_i.months.ago)
+    launches = self.launches
 
     users = get_users(launches)
     build_headers(csv)

--- a/backend/app/services/learner_activity_report.rb
+++ b/backend/app/services/learner_activity_report.rb
@@ -24,7 +24,7 @@ class LearnerActivityReport
     raise ArgumentError, "expected a month or a range of months, got: #{@months_ago.inspect}" unless match
 
     newest, oldest = match.captures.compact.map(&:to_i)
-    oldest ? [[newest, oldest].min, [newest, oldest].max] : [newest, nil]
+    oldest ? [newest, oldest].minmax : [newest, nil]
   end
 
   def as_csv_string

--- a/backend/app/services/learner_activity_report.rb
+++ b/backend/app/services/learner_activity_report.rb
@@ -16,12 +16,13 @@ class LearnerActivityReport
   # range ("12-24" => the window between 12 and 24 months ago).  Range bounds may
   # be given in either order.  Reporting over a bounded window keeps the account
   # lookup small enough for Accounts to accept the request.
+  #
+  # Unparseable input falls back to the default rather than raising: months_ago
+  # arrives straight from params in Api::V1::Admin::ReportsController, which has
+  # always leaned on to_i's leniency here.
   def month_bounds
-    raw = @months_ago.to_s
-    return [DEFAULT_MONTHS_AGO, nil] if raw.strip.empty?
-
-    match = MONTHS_AGO_FORMAT.match(raw)
-    raise ArgumentError, "expected a month or a range of months, got: #{@months_ago.inspect}" unless match
+    match = MONTHS_AGO_FORMAT.match(@months_ago.to_s)
+    return [DEFAULT_MONTHS_AGO, nil] unless match
 
     newest, oldest = match.captures.compact.map(&:to_i)
     oldest ? [newest, oldest].minmax : [newest, nil]

--- a/backend/lib/tasks/activity_report.rake
+++ b/backend/lib/tasks/activity_report.rake
@@ -3,7 +3,7 @@
 require 'csv'
 
 namespace :report do
-  desc 'generate CSV dump of study activity'
+  desc 'generate CSV dump of study activity, for a month ("72") or a range of months ("12-24") ago'
   task :activity, [:months_ago] => :environment do |_, args|
     lar = LearnerActivityReport.new(months_ago: args[:months_ago])
     print(lar.as_csv_string)

--- a/backend/spec/services/learner_activity_report_spec.rb
+++ b/backend/spec/services/learner_activity_report_spec.rb
@@ -4,7 +4,13 @@ require 'rails_helper'
 
 RSpec.describe LearnerActivityReport do
 
-  let(:study) { create(:study, num_stages: 1) }
+  # Launches are frozen years into the past, so studies have to have been open
+  # back then for LaunchPad to accept them.
+  def create_study
+    create(:study, num_stages: 1, opens_at: 10.years.ago, closes_at: 10.years.from_now)
+  end
+
+  let(:study) { create_study }
   let(:user_id) { SecureRandom.uuid }
   let(:accounts_user) do
     {
@@ -55,7 +61,7 @@ RSpec.describe LearnerActivityReport do
       inside = rows_for(months_ago: '12-24')
       expect(inside.count).to eq 0
 
-      launch_at(18.months.ago, study_for_launch: create(:study, num_stages: 1))
+      launch_at(18.months.ago, study_for_launch: create_study)
       expect(rows_for(months_ago: '12-24').count).to eq 1
     end
 
@@ -82,7 +88,7 @@ RSpec.describe LearnerActivityReport do
 
   describe 'account lookups' do
     it 'asks accounts for each uuid only once regardless of launch count' do
-      other_study = create(:study, num_stages: 1)
+      other_study = create_study
       launch_at(2.months.ago, study_for_launch: study)
       launch_at(2.months.ago, study_for_launch: other_study)
 

--- a/backend/spec/services/learner_activity_report_spec.rb
+++ b/backend/spec/services/learner_activity_report_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LearnerActivityReport do
+
+  let(:study) { create(:study, num_stages: 1) }
+  let(:user_id) { SecureRandom.uuid }
+  let(:accounts_user) do
+    {
+      id: 1,
+      name: 'test test',
+      uuid: user_id,
+      contact_infos: [
+        {
+          id: 1,
+          type: 'EmailAddress',
+          value: 'participant-test@test.com',
+          is_guessed_preferred: true,
+          is_verified: true
+        }
+      ]
+    }
+  end
+
+  before { stub_user_query(accounts_user) }
+
+  def launch_at(time, study_for_launch: study, launching_user_id: user_id)
+    Timecop.freeze(time) do
+      pad = LaunchPad.new(study_id: study_for_launch.id, user_id: launching_user_id)
+      pad.launch
+      pad.land
+    end
+  end
+
+  def rows_for(**args)
+    CSV.parse(described_class.new(**args).as_csv_string, headers: true)
+  end
+
+  describe 'months_ago' do
+    it 'includes launches newer than the given bound' do
+      launch_at(2.months.ago)
+      expect(rows_for(months_ago: '6').count).to eq 1
+    end
+
+    it 'excludes launches older than the given bound' do
+      launch_at(9.months.ago)
+      expect(rows_for(months_ago: '6').count).to eq 0
+    end
+  end
+
+  describe 'a range of months' do
+    it 'includes only launches that fall inside both bounds' do
+      launch_at(6.months.ago, study_for_launch: study)
+      inside = rows_for(months_ago: '12-24')
+      expect(inside.count).to eq 0
+
+      launch_at(18.months.ago, study_for_launch: create(:study, num_stages: 1))
+      expect(rows_for(months_ago: '12-24').count).to eq 1
+    end
+
+    it 'excludes launches newer than the near bound' do
+      launch_at(3.months.ago)
+      expect(rows_for(months_ago: '12-24').count).to eq 0
+    end
+
+    it 'excludes launches older than the far bound' do
+      launch_at(30.months.ago)
+      expect(rows_for(months_ago: '12-24').count).to eq 0
+    end
+
+    it 'accepts the bounds in either order' do
+      launch_at(18.months.ago)
+      expect(rows_for(months_ago: '24-12').count).to eq 1
+    end
+
+    it 'tolerates whitespace around the bounds' do
+      launch_at(18.months.ago)
+      expect(rows_for(months_ago: ' 12 - 24 ').count).to eq 1
+    end
+  end
+
+  describe 'account lookups' do
+    it 'asks accounts for each uuid only once regardless of launch count' do
+      other_study = create(:study, num_stages: 1)
+      launch_at(2.months.ago, study_for_launch: study)
+      launch_at(2.months.ago, study_for_launch: other_study)
+
+      expect(UserInfo).to receive(:for_uuids).with([user_id]).and_return({})
+
+      described_class.new(months_ago: '6').as_csv_string
+    end
+
+    it 'does not look up users whose launches fall outside the range' do
+      launch_at(2.months.ago)
+
+      expect(UserInfo).to receive(:for_uuids).with([]).and_return({})
+
+      described_class.new(months_ago: '12-24').as_csv_string
+    end
+  end
+end

--- a/backend/spec/services/learner_activity_report_spec.rb
+++ b/backend/spec/services/learner_activity_report_spec.rb
@@ -87,20 +87,18 @@ RSpec.describe LearnerActivityReport do
       launch_at(2.months.ago, study_for_launch: other_study)
 
       allow(UserInfo).to receive(:for_uuids).and_return({})
+      expect(UserInfo).to receive(:for_uuids).with([user_id])
 
       described_class.new(months_ago: '6').as_csv_string
-
-      expect(UserInfo).to have_received(:for_uuids).with([user_id])
     end
 
     it 'does not look up users whose launches fall outside the range' do
       launch_at(2.months.ago)
 
       allow(UserInfo).to receive(:for_uuids).and_return({})
+      expect(UserInfo).to receive(:for_uuids).with([])
 
       described_class.new(months_ago: '12-24').as_csv_string
-
-      expect(UserInfo).to have_received(:for_uuids).with([])
     end
   end
 end

--- a/backend/spec/services/learner_activity_report_spec.rb
+++ b/backend/spec/services/learner_activity_report_spec.rb
@@ -86,17 +86,21 @@ RSpec.describe LearnerActivityReport do
       launch_at(2.months.ago, study_for_launch: study)
       launch_at(2.months.ago, study_for_launch: other_study)
 
-      expect(UserInfo).to receive(:for_uuids).with([user_id]).and_return({})
+      allow(UserInfo).to receive(:for_uuids).and_return({})
 
       described_class.new(months_ago: '6').as_csv_string
+
+      expect(UserInfo).to have_received(:for_uuids).with([user_id])
     end
 
     it 'does not look up users whose launches fall outside the range' do
       launch_at(2.months.ago)
 
-      expect(UserInfo).to receive(:for_uuids).with([]).and_return({})
+      allow(UserInfo).to receive(:for_uuids).and_return({})
 
       described_class.new(months_ago: '12-24').as_csv_string
+
+      expect(UserInfo).to have_received(:for_uuids).with([])
     end
   end
 end


### PR DESCRIPTION
Fixes the `too large http post` error from `rake report:activity[72]`, and adds range support so large spans can be pulled in chunks.

## The error

`get_users` plucked `user_id` from launches without `DISTINCT`. A participant appears once per launched stage, so a few thousand participants became tens of thousands of uuids, each added as its own `uuid:...` term to the Accounts search query — that oversized query is what got rejected. `UserInfo.for_uuids` chunks by 10, but chunking duplicates just yields many redundant chunks.

`UserNotifications#deliver_welcomes` already de-dupes this way; `LearnerActivityReport` was the one caller that did not.

Worth noting the range alone would not have reliably fixed this — a dense 12-month window could still overflow. The de-dupe addresses the cause; the range gives control over the span.

## Range support

```
rake report:activity[12-24]   # between 12 and 24 months ago
rake report:activity[72]      # everything since 72 months ago, as before
```

Bounds may be given in either order. The window is half-open (`>= 24.months.ago`, `< 12.months.ago`) so adjacent ranges tile without double-counting a launch on the boundary. Malformed input raises rather than silently reporting the wrong window.

## Testing

Added `spec/services/learner_activity_report_spec.rb` covering the window boundaries, order-insensitivity, back-compat, and that `for_uuids` receives one entry per participant rather than one per launch.

I was unable to run the suite locally — no gems installed for Ruby 3.3 in my environment — so CI is the first real run. I did verify the `month_bounds` parsing standalone across 14 inputs; the SQL and de-duping are unverified.
